### PR TITLE
26: Implementing top level account query.

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -16,6 +16,10 @@ const accountFields = {
   code: {
     type: GraphQLString,
     resolve: ({ address }) => web3.eth.getCode(address)
+  },
+  transactionCount: {
+    type: longType,
+    resolve: ({ address }) => web3.eth.getTransactionCount(address)
   }
 };
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLObjectType, GraphQLInt } from 'graphql';
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql';
 import { longType } from './common-types';
 import { web3 } from './web3';
 
@@ -11,11 +11,11 @@ const accountFields = {
   },
   code: {
     type: GraphQLString,
-    resolve: ({ address }) => web3.eth.getCode(address)
+    resolve: ({ address }) => web3.eth.getCode(address),
   },
   transactionCount: {
     type: GraphQLInt,
-    resolve: ({ address }) => web3.eth.getTransactionCount(address)
+    resolve: ({ address }) => web3.eth.getTransactionCount(address),
   },
 };
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLObjectType } from 'graphql';
+import { GraphQLString, GraphQLObjectType, GraphQLInt } from 'graphql';
 import { longType } from './common-types';
 import { web3 } from './web3';
 
@@ -18,7 +18,7 @@ const accountFields = {
     resolve: ({ address }) => web3.eth.getCode(address)
   },
   transactionCount: {
-    type: longType,
+    type: GraphQLInt,
     resolve: ({ address }) => web3.eth.getTransactionCount(address)
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const schema = new GraphQLSchema({
       account: {
         type: Account,
         args: { address: { type: GraphQLString } },
-        resolve: (obj, { address }) => { return { address } }
+        resolve: (obj, { address }) => ({ address }),
       },
       block: {
         type: Block,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from 'graphql';
 
 import * as express from 'express';
+import { Account } from './account';
 import { Block } from './block';
 import { web3 } from './web3';
 import { DecodedTransaction, Erc20TransactionType } from './transaction';
@@ -24,6 +25,11 @@ const schema = new GraphQLSchema({
     name: 'Query',
     description: 'Query root',
     fields: {
+      account: {
+        type: Account,
+        args: { address: { type: GraphQLString } },
+        resolve: (obj, { address }) => { return { address } }
+      },
       block: {
         type: Block,
         args: { number: { type: GraphQLInt } },
@@ -33,7 +39,7 @@ const schema = new GraphQLSchema({
         type: new GraphQLList(Block),
         args: { from: { type: GraphQLInt }, to: { type: GraphQLInt } },
         resolve: (obj, { from, to }) => Promise.all(_.range(from, to + 1).map(i => web3.eth.getBlock(i, true)))
-      }
+      },
     }
   })
 });


### PR DESCRIPTION
Supporting the following fields:
- balance => calls getBalance from JSON-RPC.
- code => calls getCode from JSON-RPC.
- transactionCount => calls getTransactionCount from JSON-RPC.

```
{
   account(address="0x9bc0ad...") {
      balance
      code
      transactionCount
   }
}
```