### PR TITLE
101: Implement Block->transactionRoles field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "precommit": "npm run test && $(npm bin)/lint-staged"
   },
   "lint-staged": {
-    "*.{ts}": [
+    "*.ts": [
       "tslint --fix -t stylish -c tslint.json -p tsconfig.json",
       "prettier --parser typescript --write",
       "git add"

--- a/src/__tests__/core/block.transactionsRoles.test.ts
+++ b/src/__tests__/core/block.transactionsRoles.test.ts
@@ -1,0 +1,320 @@
+import { testGraphql } from '../utils';
+
+const { execQuery } = testGraphql();
+
+test('block->transactionsRoles: error when an invalid from address is specified', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(from: "0x1234") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].message).toMatch(/^Expected type Address/);
+});
+
+test('block->transactionsRoles: from address only, no matching transactions', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(from: "0xE99DDae9181957E91b457E4c79A1B577E55a5742") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const expected = { data: { block: { transactionsRoles: [] } } };
+  const result = await execQuery(query);
+  expect(result).toEqual(expected);
+});
+
+test('block->transactionsRoles: from address only, matching transactions returned', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(from: "0xCcF1D27AfE45BA5F8c15265199E5b635AF4cb889") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const expected = {
+    data: {
+      block: {
+        transactionsRoles: [
+          {
+            hash: '0xb112efc908b879b72e167261a8456bc658f922c6c5914540675de657cbf106ca',
+            from: {
+              address: '0xCcF1D27AfE45BA5F8c15265199E5b635AF4cb889',
+            },
+            to: {
+              address: '0xA4eA687A2A7F29cF2dc66B39c68e4411C0D00C49',
+            },
+          },
+        ],
+      },
+    },
+  };
+  const result = await execQuery(query);
+  expect(result).toEqual(expected);
+});
+
+test('block->transactionsRoles: error when an invalid to address is specified', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(to: "0x1234") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].message).toMatch(/^Expected type Address/);
+});
+
+test('block->transactionsRoles: to address only, no matching transactions', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(to: "0xCcF1D27AfE45BA5F8c15265199E5b635AF4cb889") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const expected = { data: { block: { transactionsRoles: [] } } };
+  const result = await execQuery(query);
+  expect(result).toEqual(expected);
+});
+
+test('block->transactionsRoles: to address only, matching transactions returned', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(to: "0xA4eA687A2A7F29cF2dc66B39c68e4411C0D00C49") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const expected = {
+    data: {
+      block: {
+        transactionsRoles: [
+          {
+            hash: '0xb112efc908b879b72e167261a8456bc658f922c6c5914540675de657cbf106ca',
+            from: {
+              address: '0xCcF1D27AfE45BA5F8c15265199E5b635AF4cb889',
+            },
+            to: {
+              address: '0xA4eA687A2A7F29cF2dc66B39c68e4411C0D00C49',
+            },
+          },
+        ],
+      },
+    },
+  };
+  const result = await execQuery(query);
+  expect(result).toEqual(expected);
+});
+
+test('block->transactionsRoles: error when neither to address or from address are provided', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(from: "", to: "") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(2);
+  expect(result.errors[0].message).toMatch(/^Expected type Address/);
+  expect(result.errors[1].message).toMatch(/^Expected type Address/);
+});
+
+test('block->transactionsRoles: error when valid from address and invalid to address is provided', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(from: "0x364904669aA5eDd0d5BF8e64E63442152344d5CA", to: "0x1234") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].message).toMatch(/^Expected type Address/);
+});
+
+test('block->transactionsRoles: both from and to addresses, no matching transactions', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(from: "0xA4eA687A2A7F29cF2dc66B39c68e4411C0D00C49", to: "0xCcF1D27AfE45BA5F8c15265199E5b635AF4cb889") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const expected = { data: { block: { transactionsRoles: [] } } };
+  const result = await execQuery(query);
+  expect(result).toEqual(expected);
+});
+
+test('block->transactionsRoles: both from and to addresses, matching transactions returned', async () => {
+  const query = `
+    {
+      block(number: 5755715) {
+        transactionsRoles(from: "0xCcF1D27AfE45BA5F8c15265199E5b635AF4cb889", to: "0xA4eA687A2A7F29cF2dc66B39c68e4411C0D00C49") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const expected = {
+    data: {
+      block: {
+        transactionsRoles: [
+          {
+            hash: '0xb112efc908b879b72e167261a8456bc658f922c6c5914540675de657cbf106ca',
+            from: {
+              address: '0xCcF1D27AfE45BA5F8c15265199E5b635AF4cb889',
+            },
+            to: {
+              address: '0xA4eA687A2A7F29cF2dc66B39c68e4411C0D00C49',
+            },
+          },
+        ],
+      },
+    },
+  };
+  const result = await execQuery(query);
+  expect(result).toEqual(expected);
+});
+
+test('block->transactionsRoles: both from and to addresses, multiple matching transactions returned, matched on to only', async () => {
+  const query = `
+    {
+      block(number: 5812225) {
+        transactionsRoles(from: "0xCcF1D27AfE45BA5F8c15265199E5b635AF4cb889", to: "0xfa52274dd61e1643d2205169732f29114bc240b3") {
+          hash
+          from {
+            address
+          }
+          to {
+            address
+          }
+        }
+      }
+    }
+  `;
+
+  const expected = {
+    data: {
+      block: {
+        transactionsRoles: [
+          {
+            hash: '0x63f15d479bca31d321071035e6999d44f9a8244513b262c29ed549b3c3ae77e3',
+            from: {
+              address: '0x7f7bF1f8867F3bC41b2B5C2f3BCc5798bc71b391',
+            },
+            to: {
+              address: '0xFa52274DD61E1643d2205169732f29114BC240b3',
+            },
+          },
+          {
+            hash: '0x281ca150bcc5a49d5028a0860ef57a8b84a285e1080a88d3a74d00126a32b6b9',
+            from: {
+              address: '0xfAEe59A232abc5A86286f089F37615FFE48D0A27',
+            },
+            to: {
+              address: '0xFa52274DD61E1643d2205169732f29114BC240b3',
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  const result = await execQuery(query);
+  expect(result).toEqual(expected);
+});

--- a/src/model/core/EthqlBlock.ts
+++ b/src/model/core/EthqlBlock.ts
@@ -13,6 +13,11 @@ interface TransactionsInvolvingArgs {
   participants: string[];
 }
 
+interface TransactionsRolesArgs {
+  from: string;
+  to: string;
+}
+
 class EthqlBlock implements EthqlBlock {
   public transactions: EthqlTransaction[];
 
@@ -36,6 +41,15 @@ class EthqlBlock implements EthqlBlock {
       throw new Error('Expected at least one participant.');
     }
     return this.transactions.filter(tx => participants.some(p => tx.from.equals(p) || tx.to.equals(p)));
+  }
+
+  public transactionsRoles({ from, to }: TransactionsRolesArgs) {
+    if (!(from || to)) {
+      throw new Error('Expected one or both of a from address and a to address.');
+    }
+
+    // Note: the EthqlAccount#equals method is lenient to nulls/undefined.
+    return this.transactions.filter(tx => tx.from.equals(from) || tx.to.equals(to));
   }
 }
 

--- a/src/schema/core.graphql
+++ b/src/schema/core.graphql
@@ -95,7 +95,7 @@ type Block {
   Gets all transactions from this block where the provided addresses take the indicated roles.
   If a filter is passed, only the transactions matching the filter will be returned.
   """
-  transactionsRoles(from: String, to: String, filter: TransactionFilter): [Transaction]
+  transactionsRoles(from: Address, to: Address, filter: TransactionFilter): [Transaction]
 }
 
 """


### PR DESCRIPTION
This fields retrieves only the transactions whose `from` and `to` addresses match the ones provided as arguments.

```
block(number: 1234) {
  transactionsRoles(from: "0x1234...", to: "0x3456...") {
  }
}
```

^^ This query would only return those transactions whose from and to addresses matched the provided ones.

It is possible to provide only the `from` or `to` address when fetching this field, in which case all transactions where the address appears in the appropriate field are returned.

If the user doesn't care about directionality (i.e. which address is source and which is target), they should use the `transactionsParticipants` field instead.

[ch101]