### PR TITLE
Implement TransactionFilter->withInput in all TX queries.

### DIFF
--- a/src/__tests__/core/block.transactionFilter.test.ts
+++ b/src/__tests__/core/block.transactionFilter.test.ts
@@ -1,0 +1,162 @@
+import { testGraphql } from '../utils';
+
+const { execQuery } = testGraphql();
+
+describe('transactionFilter on Block->transactions', async () => {
+  test('withInput: true value, returns only transactions with input data', async () => {
+    const query = `
+      {
+        block(number: 5783495) {
+          transactions(filter: { withInput: true }) {
+            hash
+            inputData
+          }
+        }
+      }
+    `;
+
+    const result = await execQuery(query);
+    expect(result.data.block.transactions).toHaveLength(2);
+    for (let tx of result.data.block.transactions) {
+      expect(tx.inputData).toMatch(/0x.+/);
+    }
+  });
+
+  test('withInput: false value, returns only transactions without input data', async () => {
+    const query = `
+      {
+        block(number: 5783495) {
+          transactions(filter: { withInput: false }) {
+            hash
+            inputData
+          }
+        }
+      }
+    `;
+
+    const expected = {
+      data: {
+        block: {
+          transactions: [
+            {
+              hash: '0x238dff8a480c6784455115224b6eafa8a8e5f8830a61d20aa241ed5fea326a9b',
+              inputData: null,
+            },
+            {
+              hash: '0x4102ad582cc7142372e0c0147c876ad679a7bb9d84c1abe4ab55b8190b6a4487',
+              inputData: null,
+            },
+            {
+              hash: '0xe4da0f1943179898a5ca3f67615a9aab00697b31acdabdcf8e2539d7884ed852',
+              inputData: null,
+            },
+          ],
+        },
+      },
+    };
+    const result = await execQuery(query);
+    expect(result).toEqual(expected);
+  });
+
+  test('withInput: true value, no matching transactions', async () => {
+    const query = `
+      {
+        block(number: 63515) {
+          transactions(filter: { withInput: true }) {
+            hash
+          }
+        }
+      }
+    `;
+
+    const expected = { data: { block: { transactions: [] } } };
+    const result = await execQuery(query);
+    expect(result).toEqual(expected);
+  });
+
+  test('withInput: invalid query', async () => {
+    const query = `
+      {
+        block(number: 63515) {
+          transactions (filter: yes) {
+            hash
+          }
+        }
+      }
+    `;
+
+    const result = await execQuery(query);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/^Expected type TransactionFilter/);
+  });
+});
+
+describe('transactionFilter on Block->transactionsInvolving', async () => {
+  test('withInput: true value, returns only transactions with input data', async () => {
+    const query = `
+      {
+        block(number: 5812961) {
+          transactionsInvolving(participants: ["0x10aeaff3b9db519820da523f84fdcbaeac2b1920"], filter: { withInput: true }) {
+            hash
+            inputData
+          }
+        }
+      }
+    `;
+
+    const result = await execQuery(query);
+    expect(result.data.block.transactionsInvolving).toHaveLength(1);
+    expect(result.data.block.transactionsInvolving[0].inputData).toMatch(/0x.+/);
+  });
+
+  test('withInput: false value, returns only transactions without input data (none in this case)', async () => {
+    const query = `
+      {
+        block(number: 5812961) {
+          transactionsInvolving(participants: ["0x10aeaff3b9db519820da523f84fdcbaeac2b1920"], filter: { withInput: false }) {
+            hash
+            inputData
+          }
+        }
+      }
+    `;
+
+    const result = await execQuery(query);
+    expect(result.data.block.transactionsInvolving).toHaveLength(0);
+  });
+});
+
+describe('transactionFilter on Block->transactionsRoles', async () => {
+  test('withInput: true value, returns only transactions with input data', async () => {
+    const query = `
+      {
+        block(number: 5812961) {
+          transactionsRoles(from: "0x10aeaff3b9db519820da523f84fdcbaeac2b1920", filter: { withInput: true }) {
+            hash
+            inputData
+          }
+        }
+      }
+    `;
+
+    const result = await execQuery(query);
+    expect(result.data.block.transactionsRoles).toHaveLength(1);
+    expect(result.data.block.transactionsRoles[0].inputData).toMatch(/0x.+/);
+  });
+
+  test('withInput: false value, returns only transactions without input data (none in this case)', async () => {
+    const query = `
+      {
+        block(number: 5812961) {
+          transactionsRoles(from: "0x10aeaff3b9db519820da523f84fdcbaeac2b1920", filter: { withInput: false }) {
+            hash
+            inputData
+          }
+        }
+      }
+    `;
+
+    const result = await execQuery(query);
+    expect(result.data.block.transactionsRoles).toHaveLength(0);
+  });
+});

--- a/src/model/core/EthqlBlock.ts
+++ b/src/model/core/EthqlBlock.ts
@@ -4,52 +4,78 @@ import EthqlTransaction from './EthqlTransaction';
 type Overwrite<T1, T2> = { [P in Exclude<keyof T1, keyof T2>]: T1[P] } & T2;
 
 type Overwritten = {
-  transactions: EthqlTransaction[];
+  transactions: (filter: WithTransactionFilter) => EthqlTransaction[];
 };
 
 interface EthqlBlock extends Overwrite<Block, Overwritten> {}
 
-interface TransactionsInvolvingArgs {
+interface TransactionFilter {
+  withInput?: boolean;
+  withLogs?: boolean;
+}
+
+interface WithTransactionFilter {
+  filter?: TransactionFilter;
+}
+
+interface TransactionsInvolvingArgs extends WithTransactionFilter {
   participants: string[];
 }
 
-interface TransactionsRolesArgs {
+interface TransactionsRolesArgs extends WithTransactionFilter {
   from: string;
   to: string;
 }
 
 class EthqlBlock implements EthqlBlock {
-  public transactions: EthqlTransaction[];
+  private static transactionFilter(filter: TransactionFilter): (tx: EthqlTransaction) => boolean {
+    return !filter || filter.withInput === undefined //
+      ? tx => true
+      : filter.withInput
+        ? tx => !!tx.inputData
+        : tx => !tx.inputData;
+  }
+
+  //tslint:disable-next-line
+  private _transactions: EthqlTransaction[];
 
   constructor(block: Block) {
     const { transactions, ...rest } = block;
     Object.assign(this, rest);
 
-    this.transactions = transactions.map(t => new EthqlTransaction(t));
+    this._transactions = transactions.map(t => new EthqlTransaction(t));
+  }
+
+  public transactions({ filter }: WithTransactionFilter) {
+    return this._transactions.filter(EthqlBlock.transactionFilter(filter));
   }
 
   public transactionCount() {
-    return this.transactions.length;
+    return this._transactions.length;
   }
 
   public transactionAt(args): EthqlTransaction {
-    return this.transactions[args.index];
+    return this._transactions[args.index];
   }
 
-  public transactionsInvolving({ participants }: TransactionsInvolvingArgs): EthqlTransaction[] {
+  public transactionsInvolving({ participants, filter }: TransactionsInvolvingArgs): EthqlTransaction[] {
     if (!participants || !participants.length) {
       throw new Error('Expected at least one participant.');
     }
-    return this.transactions.filter(tx => participants.some(p => tx.from.equals(p) || tx.to.equals(p)));
+    return this._transactions
+      .filter(tx => participants.some(p => tx.from.equals(p) || tx.to.equals(p)))
+      .filter(EthqlBlock.transactionFilter(filter));
   }
 
-  public transactionsRoles({ from, to }: TransactionsRolesArgs) {
+  public transactionsRoles({ from, to, filter }: TransactionsRolesArgs): EthqlTransaction[] {
     if (!(from || to)) {
       throw new Error('Expected one or both of a from address and a to address.');
     }
 
     // Note: the EthqlAccount#equals method is lenient to nulls/undefined.
-    return this.transactions.filter(tx => tx.from.equals(from) || tx.to.equals(to));
+    return this._transactions
+      .filter(tx => tx.from.equals(from) || tx.to.equals(to))
+      .filter(EthqlBlock.transactionFilter(filter));
   }
 }
 

--- a/src/model/core/EthqlTransaction.ts
+++ b/src/model/core/EthqlTransaction.ts
@@ -24,7 +24,7 @@ class EthqlTransaction {
 
     this.from = new EthqlAccount(from);
     this.to = new EthqlAccount(to);
-    this.inputData = tx.input;
+    this.inputData = !tx.input || tx.input === '0x' ? null : tx.input;
   }
 
   public get index() {


### PR DESCRIPTION
All `block->transactions*` queries accept a TransactionFilter input argument that contains two fields of type Boolean:

* `withLogs`
* `withInput`

This story implements the `withInput` filter, such that when the value is `true`, only those transactions that have input data are returned.

[ch102]