### PR TITLE
Fix transaction decoding

### DIFF
--- a/src/__tests__/core/transaction.test.ts
+++ b/src/__tests__/core/transaction.test.ts
@@ -46,3 +46,22 @@ test('transaction: error when malformed hash provided', async () => {
   expect(result.errors).toHaveLength(1);
   expect(result.errors[0].message).toMatch(/^Expected type Hash/);
 });
+
+test('transaction: requesting decoded field', async () => {
+  const query = `
+      {
+        transaction(hash: "0xd72b7a9e3461ee34b37da8b9bbc1b58e7bad37702c404400f01631080262a293") {
+          nonce
+          decoded {
+            operation
+          }
+      }
+   }
+ `;
+
+ const expected =  {data: { transaction: { decoded:
+   { operation: 'transfer' }, nonce: 5125979 } } };
+
+ const result = await graphql(schema, query);
+ expect(result).toEqual(expected);
+});

--- a/src/resolvers/transaction.ts
+++ b/src/resolvers/transaction.ts
@@ -43,12 +43,12 @@ const processors = {
 };
 
 const decodeTransaction: IFieldResolver<any, any> = (transaction, args) => {
-  const { inputData } = transaction;
-  if (!inputData || inputData === '0x') {
+  const { input } = transaction;
+  if (!input || input === '0x') {
     return;
   }
   for (const [c, { decoder, transformer }] of Object.entries(processors)) {
-    const decoded = decoder(inputData);
+    const decoded = decoder(input);
     if (decoded) {
       return transformer(decoded, transaction);
     }


### PR DESCRIPTION
The object returned by `web3.eth.getTransaction` provides the data sent
along with the transaction via an attribute named `input`.

This commit enables the return of expected functionality when requesting
a transaction's decoded field.