### PR TITLE
Fix validation in block selection and implement more tests

### DIFF
--- a/src/__tests__/core/account.test.ts
+++ b/src/__tests__/core/account.test.ts
@@ -35,13 +35,13 @@ test('account: error when address is invalid', async () => {
 test('account: select account balance', async () => {
   const query = `
     {
-      account(address: "0xF7c74BBC9b7e643193d46D9889538899321e5712") {
+      account(address: "0x0000000000000000000000000000000000000000") {
         balance
       }
     }
   `;
 
-  const expected = { data: { account: { balance: 201749298394112000 } } };
   const result = await execQuery(query);
-  expect(result).toEqual(expected);
+  expect(result.errors).toBeUndefined();
+  expect(result.data.account.balance).toBeGreaterThan(0);
 });

--- a/src/__tests__/core/account.test.ts
+++ b/src/__tests__/core/account.test.ts
@@ -13,7 +13,6 @@ test('account: select by address', async () => {
   `;
 
   const expected = { data: { account: { code: '0x', transactionCount: 0 } } };
-
   const result = await execQuery(query);
   expect(result).toEqual(expected);
 });
@@ -31,4 +30,18 @@ test('account: error when address is invalid', async () => {
   const result = await execQuery(query);
   expect(result.errors).toHaveLength(1);
   expect(result.errors[0].message).toMatch(/^Expected type Address\!/);
+});
+
+test('account: select account balance', async () => {
+  const query = `
+    {
+      account(address: "0xF7c74BBC9b7e643193d46D9889538899321e5712") {
+        balance
+      }
+    }
+  `;
+
+  const expected = { data: { account: { balance: 201749298394112000 } } };
+  const result = await execQuery(query);
+  expect(result).toEqual(expected);
 });

--- a/src/__tests__/core/block.test.ts
+++ b/src/__tests__/core/block.test.ts
@@ -116,6 +116,34 @@ test('block: error when selecting block by invalid hash', async () => {
   expect(result.errors[0].message).toMatch(/^Expected type Hash/);
 });
 
+test('block: error when selecting block with no number, hash, or tag', async () => {
+  const query = `
+    {
+      block {
+        number
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].message).toMatch(/^Expected either number, hash or tag argument/);
+});
+
+test('block: error when selecting block with more than one argument', async () => {
+  const query = `
+    {
+      block(hash: "0x4b3c1d7e65a507b62734feca1ee9f27a5379e318bd52ae62de7ba67dbeac66a3", number: 12344)   {
+        number
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].message).toMatch(/^Only one of number, hash or tag argument should be provided/);
+});
+
 test('block: all scalar fields successfully returned', async () => {
   const query = `
     {

--- a/src/__tests__/core/blockRange.test.ts
+++ b/src/__tests__/core/blockRange.test.ts
@@ -131,10 +131,24 @@ test('blocksRange: error when only one hash provided', async () => {
   expect(result.errors[0].message).toBe('Exactly two elements were expected: the start and end blocks.');
 });
 
-test('blocksRange: error when negative number provided', async () => {
+test('blocksRange: error when negative number provided as start', async () => {
   const query = `
     {
       blocksRange(numberRange: [-1, 122]) {
+        timestamp
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].message).toBe('Expected type BlockNumber, found -1.');
+});
+
+test('blocksRange: error when negative number provided as end', async () => {
+  const query = `
+    {
+      blocksRange(numberRange: [122, -1]) {
         timestamp
       }
     }

--- a/src/__tests__/core/blocks.test.ts
+++ b/src/__tests__/core/blocks.test.ts
@@ -42,3 +42,35 @@ test('blocks: select multiple blocks by specific hashes', async () => {
   const result = await execQuery(query);
   expect(result).toEqual(expected);
 });
+
+test('blocks: error when selecting blocks with both numbers and hashes', async () => {
+  const hashes = `["0x624d6c50f4edff05693806953b211050ef3e674ed18b1a1a6e64352086006f9e",
+      "0xbfe0f792a89bd44e6c22224a84721edfedb334e521afb365fd397442bc1b2b81",
+      "0x0cd6b3ef09f74b86fd8e17122deae11c1016a578797472bee1a3bb138323954b"]`;
+
+  const query = `
+    {
+      blocks(hashes: ${hashes}, numbers: [1202, 20502, 292]) {
+        number
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].message).toMatch(/^Only one of numbers or hashes should be provided/);
+});
+
+test('blocks: error when selecting blocks with no numbers or hashes', async () => {
+  const query = `
+    {
+      blocks {
+        number
+      }
+    }
+  `;
+
+  const result = await execQuery(query);
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors[0].message).toMatch(/^At least one of numbers or hashes must be provided/);
+});

--- a/src/model/EthqlQuery.ts
+++ b/src/model/EthqlQuery.ts
@@ -36,7 +36,8 @@ class EthqlQuery {
     tag = tag ? tag.trim().toLowerCase() : tag;
 
     const params = _.reject([blockNumber, hash, tag], _.isNil);
-    if (!args) {
+
+    if (!params.length) {
       throw new Error('Expected either number, hash or tag argument.');
     }
     if (params.length > 1) {


### PR DESCRIPTION
Introducing new tests:

- error when selecting block with no number, hash or tag.
- error when selecting block with more than one argument (number, hash, tag).
- error when selecting blocks with both numbers and hashes.
- error when selecting blocks with no numbers or hashes.
- error when selecting blockRange with starting or ending block being negative numbers.
- account->balance selection.

[ch158]