### PR TITLE
Fix parsing of Hash scalar type

### DIFF
--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -48,7 +48,7 @@ export default function initResolvers({ web3 }: EthqlContext): IResolvers {
       description: 'A Keccak hash, used to identify blocks and transactions',
       serialize: String,
       parseValue: input => {
-        return !web3.utils.isHexStrict(input) || web3.utils.hexToBytes(input).length !== 32 ? input : undefined;
+        return !web3.utils.isHexStrict(input) || web3.utils.hexToBytes(input).length !== 32 ? undefined : input;
       },
       parseLiteral: ast => {
         if (


### PR DESCRIPTION
I haven't used GraphQLScalarType before but it looks like `parseValue` only gets used when queries use variables. I ran into this issue with a query like this:

```
query MyQuery($hash: Hash) {
  transaction(hash:$hash) {
    hash
  }
}
```
with variables
```json
{"hash": "0x0abb51899e3ec31b70df13ae07e7993efddde11a07d44f7a3d9c709d6a5a3680"}
```

I'm not sure what the best place is to add tests for this stuff. Should I go ahead and add a `resolvers` directory under `__tests__` or were you all planning to just test the resolvers implicitly through all the other tests?