### PR TITLE
Fix typings for web3.utils.fromWei

### DIFF
--- a/src/types/web3/utils.d.ts
+++ b/src/types/web3/utils.d.ts
@@ -40,7 +40,8 @@ export default interface Utils {
   fromAscii(val: string): string;
   fromDecimal(val: string | number | BigNumber): string;
   fromUtf8(val: string): string;
-  fromWei(val: string | number | BigNumber, unit: Unit): string | BigNumber;
+  fromWei(val: BigNumber, unit: Unit): BigNumber;
+  fromWei(val: string | number, unit: Unit): string;
   hexToBytes(val: string): number[];
   hexToNumber(val: string | number | BigNumber): number;
   hexToNumberString(val: string | number | BigNumber): string;
@@ -61,6 +62,7 @@ export default interface Utils {
   toDecimal(val: any): number;
   toHex(val: any): string;
   toUtf8(val: any): string;
-  toWei(val: string | number | BigNumber, unit: Unit): string | BigNumber;
+  toWei(val: BigNumber, unit: Unit): string | BigNumber;
+  toWei(val: string | number, unit: Unit): string;
   unitMap: any;
 }


### PR DESCRIPTION
See the docs at http://web3js.readthedocs.io/en/1.0/web3-utils.html#id77

> If a number, or string is given it returns a number string, otherwise a BN.js instance.

As an aside, how do these slightly customized typing make it back into the main web3 typings?