### PR TITLE
Build typescript inside docker using multistages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,35 @@
-FROM node:10-alpine
+FROM node:10 as builder
 
 ENV ETHQL_INSTALL /ethql
-RUN \
-  mkdir ${ETHQL_INSTALL} && \
-  apk update && apk upgrade && \
-  apk add --no-cache bash && \
-  apk add --no-cache --virtual .build-deps git openssh python build-base
 
+RUN mkdir -p ${ETHQL_INSTALL}
 WORKDIR ${ETHQL_INSTALL}
 
 # Install dependencies. This step is performed separately to leverage Docker layer caching.
 COPY package.json yarn.lock ${ETHQL_INSTALL}/
 # Uncomment if patch-package is needed again.
 # ADD patches ${ETHQL_INSTALL}/patches
-RUN \
-  yarn install --production && \
-  apk del .build-deps && \
-  rm -rf /var/cache/apk/*
+RUN yarn install --production
+RUN cp -r node_modules node_modules_production
 
-ADD dist ${ETHQL_INSTALL}
-ENTRYPOINT [ "node", "/ethql/index.js" ]
+RUN yarn install
+
+COPY . ${ETHQL_INSTALL}
+
+RUN yarn build:ts
+
+
+
+FROM node:10-alpine
+
+ENV ETHQL_INSTALL /ethql
+
+RUN mkdir -p ${ETHQL_INSTALL}
+WORKDIR ${ETHQL_INSTALL}
+
+COPY --from=builder ${ETHQL_INSTALL}/node_modules_production ${ETHQL_INSTALL}/node_modules
+COPY --from=builder ${ETHQL_INSTALL}/dist ${ETHQL_INSTALL}/dist
+
+ENTRYPOINT [ "node", "/ethql/dist/index.js" ]
 EXPOSE 4000
 STOPSIGNAL 9

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "$(npm bin)/dotenv -- node dist/index.js",
     "dev": "$(npm bin)/nodemon -e ts -x ts-node src/index.ts",
     "debug": "$(npm bin)/dotenv -- nodemon -e ts -x ts-node --inspect src/index.ts",
-    "build": "npm run build:ts && npm run build:docker",
+    "build": "npm run build:docker",
     "build:ts": "npm run clean && $(npm bin)/patch-package && tsc && $(npm bin)/copyfiles -u 1 src/schema/**/*.graphql src/abi/** dist",
     "build:docker": "docker image build -t ethql .",
     "lint": "$(npm bin)/npm-run-all lint:ts lint:rest",


### PR DESCRIPTION
Build typescript code inside docker image using a builder docker image.
It will then use built dist/ code and node module in an alpine image.

This also reduces image size by x4 and build time by ~x2