### PR TITLE
Fix plugin dependsOn always throwing error

### DIFF
--- a/src/__tests__/bootstrap.test.ts
+++ b/src/__tests__/bootstrap.test.ts
@@ -52,13 +52,14 @@ test('bootstrap: no error when required service is present', () => {
     serviceDefinitions: {
       web3: {
         implementation: {
-          factory: () => initWeb3({
-            jsonrpc: 'http://127.0.0.1:8545',
-            batching: false
-          }),
+          factory: () =>
+            initWeb3({
+              jsonrpc: 'http://127.0.0.1:8545',
+              batching: false,
+            }),
         },
-      }
-    }
+      },
+    },
   });
 
   const plugin1: EthqlPluginFactory = () => ({

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -94,7 +94,7 @@ export function bootstrap(opts: EthqlServerOpts): EthqlBootstrapResult {
   const { schema, resolvers, serviceDefinitions } = merged;
 
   // Ensure that all service requirements are satisfied.
-  const serviceImplNames = Object.keys(_.filter(serviceDefinitions, 'implementation'));
+  const serviceImplNames = Object.keys(_.pickBy(serviceDefinitions, 'implementation'));
 
   const missingServices = plugins
     .filter(plugin => plugin.dependsOn && plugin.dependsOn.services)
@@ -102,7 +102,7 @@ export function bootstrap(opts: EthqlServerOpts): EthqlBootstrapResult {
       name,
       missing: dependsOn.services.filter(s => !serviceImplNames.includes(s)),
     }))
-    .filter(({ missing }) => missing);
+    .filter(({ missing }) => missing.length);
 
   if (missingServices.length) {
     throw new Error(ERR_MSG_MISSING_SERVICES(missingServices));


### PR DESCRIPTION
Ran into this whilst getting familiar with the project to work on #106 
`const serviceImplNames = Object.keys(_.filter(serviceDefinitions, 'implementation'));`
This is returning [ '0', '1', '2', ... ], so ERR_MSG_MISSING_SERVICES is thrown even when a correct service name is provided under dependsOn in the plugin config.
