### PR TITLE
Issue 118: Topic Filter in Logs (Rebased)

### DIFF
--- a/src/core/model/index.ts
+++ b/src/core/model/index.ts
@@ -27,12 +27,12 @@ export class EthqlAccount {
 
 export interface EthqlLog
   extends Overwrite<
-      Log,
-      {
-        logIndex: never;
-        index: number;
-      }
-    > {}
+    Log,
+    {
+      logIndex: never;
+      index: number;
+    }
+  > {}
 
 export class EthqlLog {
   constructor(log: Log, public transaction: EthqlTransaction) {
@@ -51,15 +51,15 @@ export class EthqlLog {
 
 export interface EthqlTransaction
   extends Overwrite<
-      Transaction,
-      {
-        from: EthqlAccount;
-        to: EthqlAccount;
-        input: never;
-        transactionIndex: never;
-        index: number;
-      }
-    > {}
+    Transaction,
+    {
+      from: EthqlAccount;
+      to: EthqlAccount;
+      input: never;
+      transactionIndex: never;
+      index: number;
+    }
+  > {}
 
 export class EthqlTransaction {
   public readonly from: EthqlAccount;
@@ -85,12 +85,12 @@ export class EthqlTransaction {
 
 export interface EthqlBlock
   extends Overwrite<
-      Block,
-      {
-        transactions: EthqlTransaction[];
-        miner: EthqlAccount;
-      }
-    > {}
+    Block,
+    {
+      transactions: EthqlTransaction[];
+      miner: EthqlAccount;
+    }
+  > {}
 
 export class EthqlBlock implements EthqlBlock {
   public readonly transactions: EthqlTransaction[];
@@ -141,3 +141,7 @@ export class StorageAccessor {
 }
 
 export type TransactionStatus = 'PENDING' | 'SUCCESS' | 'FAILED';
+
+export type LogFilter = {
+  topics: string[][];
+};

--- a/src/core/resolvers/transaction.ts
+++ b/src/core/resolvers/transaction.ts
@@ -4,7 +4,7 @@ import { EthqlAccount, EthqlBlock, EthqlLog, EthqlTransaction, TransactionStatus
 import { DecodedTransaction } from '../services/decoder';
 
 async function logs(obj: EthqlTransaction, args, { services }: EthqlContext): Promise<EthqlLog[]> {
-  return obj.logs || services.ethService.fetchTransactionLogs(obj);
+  return obj.logs || services.ethService.fetchTransactionLogs(obj, args.filter);
 }
 
 function decoded(obj: EthqlTransaction, args, context: EthqlContext): DecodedTransaction {

--- a/src/core/services/eth-service/impl/web3-eth-service.ts
+++ b/src/core/services/eth-service/impl/web3-eth-service.ts
@@ -2,7 +2,7 @@ import { GraphQLResolveInfo } from 'graphql';
 import * as _ from 'lodash';
 import Web3 = require('web3');
 import { EthService, fetchHints, FetchHints } from '..';
-import { EthqlAccount, EthqlBlock, EthqlLog, EthqlTransaction, TransactionStatus } from '../../../model';
+import { EthqlAccount, EthqlBlock, EthqlLog, EthqlTransaction, LogFilter, TransactionStatus } from '../../../model';
 
 export class Web3EthService implements EthService {
   constructor(private web3: Web3) {}
@@ -56,7 +56,7 @@ export class Web3EthService implements EthService {
     return address && this.web3.eth.getTransactionCount(address);
   }
 
-  public async fetchTransactionLogs(tx: EthqlTransaction, filter: any): Promise<EthqlLog[]> {
+  public async fetchTransactionLogs(tx: EthqlTransaction, filter: LogFilter): Promise<EthqlLog[]> {
     const logOpts = filter
       ? { fromBlock: tx.blockNumber, toBlock: tx.blockNumber, topics: filter.topics }
       : { fromBlock: tx.blockNumber, toBlock: tx.blockNumber };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,5 @@ const stopFn = async () => {
 
 process.on('SIGINT', stopFn);
 process.on('SIGTERM', stopFn);
+
 server.start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,5 +18,4 @@ const stopFn = async () => {
 
 process.on('SIGINT', stopFn);
 process.on('SIGTERM', stopFn);
-
 server.start();


### PR DESCRIPTION
As described in #118 when submitting queries that have the log(filter: {topics: []}) filter engaged, all logs get returned no matter what is in the topic filter. I found that the topic argument was not getting passed into getPastLogs and in the case of the log resolver specifically, we are using a the getTransactionReceipt call which does not provide a topic filter.

This PR attempts to pass the filter through the various places where logs are getting attached to the result set.

Edit: I've reopened this PR due to some misconfigurations in my local repository. This PR should be clean.